### PR TITLE
Update BuildKit `max-parallelism` to 12

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build artifact
         if: github.ref == 'refs/heads/main'
-        run: packer build -var ami-name=depot-buildkit-snapshot buildkit/buildkit.pkr.hcl
+        run: packer build -var ami-name=depot-buildkit-2-snapshot buildkit/buildkit.pkr.hcl

--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -36,7 +36,7 @@ ca = "/etc/buildkit/tlsca.crt"
 enabled = true
 gc = true
 gckeepstorage = 30000000000 # 30GB
-max-parallelism = 6
+max-parallelism = 12
 
 [worker.containerd]
 enabled = false


### PR DESCRIPTION
This doubles the number of concurrent builds BuildKit can run while not letting it run totally free and crash the build environment.