### PR TITLE
Use BuildKit 0.11.2

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build artifact
         if: github.ref == 'refs/heads/main'
-        run: packer build -var ami-name=depot-buildkit-snapshot buildkit/buildkit.pkr.hcl
+        run: packer build -var ami-name=depot-buildkit-2-snapshot buildkit/buildkit.pkr.hcl

--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -25,7 +25,7 @@ case "$(uname -m)" in
   *) echo >&2 "error: unsupported architecture: $(uname -m)"; exit 1 ;;
 esac
 
-curl -L "https://github.com/moby/buildkit/releases/download/v0.10.6/buildkit-v0.10.6.linux-${arch}.tar.gz" | \
+curl -L "https://github.com/moby/buildkit/releases/download/v0.11.2/buildkit-v0.11.2.linux-${arch}.tar.gz" | \
   tar -xz -C /usr/bin --strip-components=1
 
 mkdir -p /etc/buildkit


### PR DESCRIPTION
Upgrades the BuildKit version to v0.11.2 - this should fix some bugs with BuildKit 0.10 (including a QEMU bug), but won't yet enable access to new features like provenance until we upgrade the Depot CLI.