### PR TITLE
Pre-download machine-agent in AMI

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build artifact
         if: github.ref == 'refs/heads/main'
-        run: packer build -var ami-name=depot-buildkit-2-snapshot buildkit/buildkit.pkr.hcl
+        run: packer build -var ami-name=depot-buildkit-snapshot buildkit/buildkit.pkr.hcl

--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -17,6 +17,12 @@ swapon /swapfile
 echo "/swapfile swap swap defaults 0 0" >> /etc/fstab
 echo "vm.swappiness = 0" >> /etc/sysctl.conf
 
+# Download machine-agent v1.3.0
+
+wget -O /tmp/machine-agent.tar.gz "https://dl.depot.dev/machine-agent/download/linux/$(uname -m)/v1.3.0"
+tar -zxf /tmp/machine-agent.tar.gz --strip-components=1 --directory /usr/bin bin/machine-agent
+/usr/bin/machine-agent --version
+
 # Install BuildKit
 
 case "$(uname -m)" in


### PR DESCRIPTION
This ensures that the machine-agent is present in the AMI at boot, as rarely it can fail to download in the user-data script.