### PR TITLE
Update buildkit to v0.11.3-depot.2

### DIFF
--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -31,7 +31,7 @@ case "$(uname -m)" in
   *) echo >&2 "error: unsupported architecture: $(uname -m)"; exit 1 ;;
 esac
 
-buildkit_version="v0.11.3-depot.1"
+buildkit_version="v0.11.3-depot.2"
 curl -L "https://github.com/depot/buildkit/releases/download/${buildkit_version}/buildkit-${buildkit_version}.linux-${arch}.tar.gz" | \
   tar -xz -C /usr/bin --strip-components=1
 


### PR DESCRIPTION
https://github.com/depot/buildkit/releases/tag/v0.11.3-depot.2

I'm not updating the name as we haven't deployed the previous PR yet.