### PR TITLE
Use 40GB ephemeral disks

### DIFF
--- a/.github/workflows/buildkit.yml
+++ b/.github/workflows/buildkit.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Build artifact
         if: github.ref == 'refs/heads/main'
-        run: packer build -var ami-name=depot-buildkit-snapshot buildkit/buildkit.pkr.hcl
+        run: packer build -var ami-name=depot-buildkit-2-snapshot buildkit/buildkit.pkr.hcl

--- a/buildkit/buildkit.pkr.hcl
+++ b/buildkit/buildkit.pkr.hcl
@@ -66,7 +66,7 @@ source "amazon-ebs" "amd64" {
 
   launch_block_device_mappings {
     device_name           = "/dev/xvda"
-    volume_size           = 10
+    volume_size           = 40
     volume_type           = "gp3"
     delete_on_termination = true
   }


### PR DESCRIPTION
Use larger ephemeral disks when building AMI to give machines larger ephemeral disks at runtime.