### PR TITLE
Update machine-agent to v1.7.1

### DIFF
--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -17,9 +17,9 @@ swapon /swapfile
 echo "/swapfile swap swap defaults 0 0" >> /etc/fstab
 echo "vm.swappiness = 0" >> /etc/sysctl.conf
 
-# Download machine-agent v1.7.0
+# Download machine-agent v1.7.1
 
-wget -O /tmp/machine-agent.tar.gz "https://dl.depot.dev/machine-agent/download/linux/$(uname -m)/v1.7.0"
+wget -O /tmp/machine-agent.tar.gz "https://dl.depot.dev/machine-agent/download/linux/$(uname -m)/v1.7.1"
 tar -zxf /tmp/machine-agent.tar.gz --strip-components=1 --directory /usr/bin bin/machine-agent
 /usr/bin/machine-agent --version
 


### PR DESCRIPTION
Not changing the AMI name as we haven't deployed that AMI just yet.