### PR TITLE
perf: use pigz for gzip decompression

### DIFF
--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Update software
 yum update -y
-yum install -y git btrfs-progs
+yum install -y git btrfs-progs pigz
 
 # Disable unnecessary services
 systemctl disable postfix.service


### PR DESCRIPTION
I happened to see a log message on my desktop about pigz decompression.  I tracked it down to here:

https://github.com/containerd/containerd/blob/069d6acbe12e8247783b55ff5b719026750888f6/archive/compression/compression.go#L261-L273

Turns out that if pigz is installed then we can get parallel decompression of layers.