### PR TITLE
feat: add new GPU ami

### DIFF
--- a/buildkit/provision-gpu.sh
+++ b/buildkit/provision-gpu.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+
+# Add customizations to the GPU image here.

--- a/buildkit/provision-gpu.sh
+++ b/buildkit/provision-gpu.sh
@@ -3,3 +3,6 @@ set -ex
 
 # Add customizations to the GPU image here.
 ln -s /usr/bin/buildkit-runc /usr/bin/runc
+
+systemctl disable docker.service
+systemctl disable docker.socket

--- a/buildkit/provision-gpu.sh
+++ b/buildkit/provision-gpu.sh
@@ -2,7 +2,28 @@
 set -ex
 
 # Add customizations to the GPU image here.
-ln -s /usr/bin/buildkit-runc /usr/bin/runc
 
 systemctl disable docker.service
 systemctl disable docker.socket
+
+cat << EOF >  /etc/nvidia-container-runtime/config.toml
+disable-require = false
+
+[nvidia-container-cli]
+environment = []
+load-kmods = true
+ldconfig = "@/sbin/ldconfig"
+
+[nvidia-container-runtime]
+log-level = "info"
+mode = "auto"
+# DEPOT: prefer buildkit-runc over runc and docker-runc
+runtimes = [
+    "buildkit-runc",
+    "runc",
+    "docker-runc",
+]
+    [nvidia-container-runtime.modes.csv]
+    mount-spec-path = "/etc/nvidia-container-runtime/host-files-for-container.d"
+
+EOF

--- a/buildkit/provision-gpu.sh
+++ b/buildkit/provision-gpu.sh
@@ -2,3 +2,4 @@
 set -ex
 
 # Add customizations to the GPU image here.
+ln -s /usr/bin/buildkit-runc /usr/bin/runc


### PR DESCRIPTION
This AMI is based on the AWS deep-learning amis.
These AMIs can be run on P3 and P4 instances.

https://aws.amazon.com/releasenotes/aws-deep-learning-ami-gpu-cuda-11-5-amazon-linux-2/

We may want to try the ubuntu image as well as it has an ARM version.