### PR TITLE
Update machine-agent to v1.24.1

### DIFF
--- a/buildkit/provision.sh
+++ b/buildkit/provision.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # Versions
-machine_agent_version="v1.24.0"
+machine_agent_version="v1.24.1"
 buildkit_version="v0.11.6-depot.13"
 
 # Wait for cloud-init to finish


### PR DESCRIPTION
Intentionally not updating the AMI name as I've rolled back the API deploy (so the old name is active)